### PR TITLE
Reduce state and logging frequency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-instagram"
-version = "0.1.4"
+version = "0.2.0"
 description = "`tap-instagram` is a Singer tap for Instagram, built with the Meltano SDK for Singer Taps."
 authors = ["Prratek Ramchandani"]
 keywords = [

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -194,6 +194,7 @@ class BaseMediaStream(InstagramStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         return {
+            "user_id": context["user_id"],
             "media_id": record["id"],
             "media_type": record["media_type"],
         }
@@ -218,6 +219,7 @@ class MediaChildrenStream(BaseMediaStream):
 
     name = "media_children"
     parent_stream_type = MediaStream
+    state_partitioning_keys = ["user_id"]
     path = "/{media_id}/children"  # media_id is populated using child context keys from MediaStream
     # caption, comments_count, is_comment_enabled, like_count, media_product_type, video_title
     # not available on album children
@@ -368,6 +370,7 @@ class MediaInsightsStream(BaseMediaInsightsStream):
 
     name = "media_insights"
     parent_stream_type = MediaStream
+    state_partitioning_keys = ["user_id"]
 
 
 # Insights not available for children media objects
@@ -383,6 +386,7 @@ class StoryInsightsStream(BaseMediaInsightsStream):
 
     name = "story_insights"
     parent_stream_type = StoriesStream
+    state_partitioning_keys = ["user_id"]
 
 
 class UserInsightsStream(InstagramStream):

--- a/tap_instagram/tap.py
+++ b/tap_instagram/tap.py
@@ -64,6 +64,11 @@ class TapInstagram(Tap):
             th.DateTimeType,
             description="The earliest record date to sync",
         ),
+        th.Property(
+            "metrics_log_level",
+            th.StringType,
+            description="A user access token",
+        ),
     ).to_dict()
 
     @property


### PR DESCRIPTION
1. Update [state](https://sdk.meltano.com/en/latest/parent_streams.html) for media insights streams only for each user since parent media stream has large number of records
2. Support `metrics_log_level` [config option](https://sdk.meltano.com/en/latest/implementation/metrics.html) to customize logging frequency