### PR TITLE
Error handling to ignore a specific error for media insights

### DIFF
--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -507,6 +507,10 @@ class MediaInsightsStream(InstagramStream):
         if (
             response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
+            or
+            response.json().get("error", {}).get("error_user_title")
+            in "(#10) Not enough viewers for the media to show insights"
+
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
             return
@@ -519,6 +523,9 @@ class MediaInsightsStream(InstagramStream):
         if (
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
+            or
+            resp_json.get("error", {}).get("error_user_title")
+            in "(#10) Not enough viewers for the media to show insights"
         ):
             return
         for row in resp_json["data"]:
@@ -671,6 +678,9 @@ class StoryInsightsStream(InstagramStream):
         if (
             response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
+            or
+            response.json().get("error", {}).get("error_user_title")
+            in "(#10) Not enough viewers for the media to show insights"
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
             return
@@ -683,6 +693,9 @@ class StoryInsightsStream(InstagramStream):
         if (
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
+            or
+            resp_json.get("error", {}).get("error_user_title")
+            in "(#10) Not enough viewers for the media to show insights"
         ):
             return
         for row in resp_json["data"]:

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -504,11 +504,12 @@ class MediaInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
+        res_json = response.json()
         if (
-            response.json().get("error", {}).get("error_user_title")
+            res_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            response.json().get("error", {}).get("error_user_title")
+            res_json.get("error", {}).get("error_user_title")
             in "(#10) Not enough viewers for the media to show insights"
 
         ):
@@ -675,11 +676,12 @@ class StoryInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
+        res_json = response.json()
         if (
-            response.json().get("error", {}).get("error_user_title")
+            res_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            response.json().get("error", {}).get("error_user_title")
+            res_json.get("error", {}).get("error_user_title")
             in "(#10) Not enough viewers for the media to show insights"
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -504,13 +504,11 @@ class MediaInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
-        res_json = ""
-        res_json = response.json()
         if (
-            res_json.get("error", {}).get("error_user_title")
+            response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            res_json.get("error", {}).get("error_user_title")
+            str(response.json().get("error", {}).get("error_user_title"))
             in "(#10) Not enough viewers for the media to show insights"
 
         ):
@@ -526,7 +524,7 @@ class MediaInsightsStream(InstagramStream):
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            resp_json.get("error", {}).get("error_user_title")
+            str(resp_json.get("error", {}).get("error_user_title"))
             in "(#10) Not enough viewers for the media to show insights"
         ):
             return
@@ -677,13 +675,11 @@ class StoryInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
-        res_json = ""
-        res_json = response.json()
         if (
-            res_json.get("error", {}).get("error_user_title")
+            response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            res_json.get("error", {}).get("error_user_title")
+            str(response.json().get("error", {}).get("error_user_title"))
             in "(#10) Not enough viewers for the media to show insights"
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
@@ -698,7 +694,7 @@ class StoryInsightsStream(InstagramStream):
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            resp_json.get("error", {}).get("error_user_title")
+            str(resp_json.get("error", {}).get("error_user_title"))
             in "(#10) Not enough viewers for the media to show insights"
         ):
             return

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -508,7 +508,7 @@ class MediaInsightsStream(InstagramStream):
             response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(response.json().get("error", {}).get("error_user_title"))
+            str(response.json().get("error", {}).get("message"))
             in "(#10) Not enough viewers for the media to show insights"
 
         ):
@@ -524,7 +524,7 @@ class MediaInsightsStream(InstagramStream):
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(resp_json.get("error", {}).get("error_user_title"))
+            str(resp_json.get("error", {}).get("message"))
             in "(#10) Not enough viewers for the media to show insights"
         ):
             return
@@ -679,7 +679,7 @@ class StoryInsightsStream(InstagramStream):
             response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(response.json().get("error", {}).get("error_user_title"))
+            str(response.json().get("error", {}).get("message"))
             in "(#10) Not enough viewers for the media to show insights"
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
@@ -694,7 +694,7 @@ class StoryInsightsStream(InstagramStream):
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(resp_json.get("error", {}).get("error_user_title"))
+            str(resp_json.get("error", {}).get("message"))
             in "(#10) Not enough viewers for the media to show insights"
         ):
             return

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -508,9 +508,8 @@ class MediaInsightsStream(InstagramStream):
             response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(response.json().get("error", {}).get("message"))
-            in "(#10) Not enough viewers for the media to show insights"
-
+            "(#10) Not enough viewers for the media to show insights"
+            in str(response.json().get("error", {}).get("message"))
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
             return
@@ -524,8 +523,8 @@ class MediaInsightsStream(InstagramStream):
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(resp_json.get("error", {}).get("message"))
-            in "(#10) Not enough viewers for the media to show insights"
+            "(#10) Not enough viewers for the media to show insights"
+            in str(resp_json.get("error", {}).get("message"))
         ):
             return
         for row in resp_json["data"]:
@@ -679,8 +678,8 @@ class StoryInsightsStream(InstagramStream):
             response.json().get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(response.json().get("error", {}).get("message"))
-            in "(#10) Not enough viewers for the media to show insights"
+            "(#10) Not enough viewers for the media to show insights"
+            in str(response.json().get("error", {}).get("message"))
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
             return
@@ -694,8 +693,8 @@ class StoryInsightsStream(InstagramStream):
             resp_json.get("error", {}).get("error_user_title")
             == "Media posted before business account conversion"
             or
-            str(resp_json.get("error", {}).get("message"))
-            in "(#10) Not enough viewers for the media to show insights"
+            "(#10) Not enough viewers for the media to show insights"
+            in str(resp_json.get("error", {}).get("message"))
         ):
             return
         for row in resp_json["data"]:

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -504,6 +504,7 @@ class MediaInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
+        res_json = ""
         res_json = response.json()
         if (
             res_json.get("error", {}).get("error_user_title")
@@ -676,6 +677,7 @@ class StoryInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
+        res_json = ""
         res_json = response.json()
         if (
             res_json.get("error", {}).get("error_user_title")


### PR DESCRIPTION
Error handling to ignore the below specific error for media insights which is a limitation as described [here](https://developers.facebook.com/docs/instagram-api/reference/ig-media/insights/)

"Not enough viewers for the media to show insights"