### PR TITLE
handle error in validate_response

### DIFF
--- a/tap_instagram/client.py
+++ b/tap_instagram/client.py
@@ -65,11 +65,8 @@ class InstagramStream(RESTStream):
         yield from extract_jsonpath(self.records_jsonpath, input=response.json())
 
     def validate_response(self, response: requests.Response) -> None:
-        if (
-            response.status_code == 400
-            and 'Unsupported get request' in str(
-                response.json().get("error", {}).get("message")
-            )
+        if response.status_code == 400 and "Unsupported get request" in str(
+            response.json().get("error", {}).get("message")
         ):
             msg = (
                 f"{response.status_code} Client Error: "

--- a/tap_instagram/client.py
+++ b/tap_instagram/client.py
@@ -67,18 +67,22 @@ class InstagramStream(RESTStream):
     def validate_response(self, response: requests.Response) -> None:
         if (
             response.status_code == 400
-            and 'Unsupported get request' in str(response.json().get("error", {}).get("message"))   
+            and 'Unsupported get request' in str(
+                response.json().get("error", {}).get("message")
+            )
         ):
             msg = (
                 f"{response.status_code} Client Error: "
-                f"{response.reason} - {response.json()['error']['message']} for path: {self.path}"
+                f"{response.reason} - {response.json()['error']['message']}"
+                f" for path: {self.path}"
             )
             raise UnsupportedGetRequestError(msg)
 
-        elif 401 <= response.status_code < 500:
+        elif 400 <= response.status_code < 500:
             msg = (
                 f"{response.status_code} Client Error: "
-                f"{response.reason} - {response.json()['error']['message']} for path: {self.path}"
+                f"{response.reason} - {response.json()['error']['message']}"
+                f" for path: {self.path}"
             )
             raise FatalAPIError(msg)
 
@@ -113,7 +117,7 @@ class InstagramStream(RESTStream):
 
 class UnsupportedGetRequestError(Exception):
     """
-    Error object to facilitate skipping IDs that cause trouble 
-    with the API but aren't themselves grounds for ending the 
+    Error object to facilitate skipping IDs that cause trouble
+    with the API but aren't themselves grounds for ending the
     entire ingestion process.
     """

--- a/tap_instagram/client.py
+++ b/tap_instagram/client.py
@@ -65,7 +65,17 @@ class InstagramStream(RESTStream):
         yield from extract_jsonpath(self.records_jsonpath, input=response.json())
 
     def validate_response(self, response: requests.Response) -> None:
-        if 400 <= response.status_code < 500:
+        if (
+            response.status_code == 400
+            and 'Unsupported get request' in str(response.json().get("error", {}).get("message"))   
+        ):
+            msg = (
+                f"{response.status_code} Client Error: "
+                f"{response.reason} - {response.json()['error']['message']} for path: {self.path}"
+            )
+            raise UnsupportedGetRequestError(msg)
+
+        elif 401 <= response.status_code < 500:
             msg = (
                 f"{response.status_code} Client Error: "
                 f"{response.reason} - {response.json()['error']['message']} for path: {self.path}"
@@ -78,3 +88,32 @@ class InstagramStream(RESTStream):
                 f"{response.reason} for path: {self.path}"
             )
             raise RetriableAPIError(msg)
+
+    def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
+        """Return a generator of row-type dictionary objects.
+
+        Each row emitted should be a dictionary of property names to their values.
+
+        Args:
+            context: Stream partition or context dictionary.
+
+        Yields:
+            One item per (possibly processed) record in the API.
+        """
+        try:
+            for record in self.request_records(context):
+                transformed_record = self.post_process(record, context)
+                if transformed_record is None:
+                    # Record filtered out during post_process()
+                    continue
+                yield transformed_record
+        except UnsupportedGetRequestError as e:
+            self.logger.warning(e)
+
+
+class UnsupportedGetRequestError(Exception):
+    """
+    Error object to facilitate skipping IDs that cause trouble 
+    with the API but aren't themselves grounds for ending the 
+    entire ingestion process.
+    """

--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -504,12 +504,10 @@ class MediaInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
-        if (
-            response.json().get("error", {}).get("error_user_title")
-            == "Media posted before business account conversion"
-            or
-            "(#10) Not enough viewers for the media to show insights"
-            in str(response.json().get("error", {}).get("message"))
+        if response.json().get("error", {}).get(
+            "error_user_title"
+        ) == "Media posted before business account conversion" or "(#10) Not enough viewers for the media to show insights" in str(
+            response.json().get("error", {}).get("message")
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
             return
@@ -519,12 +517,10 @@ class MediaInsightsStream(InstagramStream):
         resp_json = response.json()
         # Handle the specific case where FB returns error because media was posted before business acct creation
         # TODO: Refactor to raise a specific error in validate_response and handle that instead
-        if (
-            resp_json.get("error", {}).get("error_user_title")
-            == "Media posted before business account conversion"
-            or
-            "(#10) Not enough viewers for the media to show insights"
-            in str(resp_json.get("error", {}).get("message"))
+        if resp_json.get("error", {}).get(
+            "error_user_title"
+        ) == "Media posted before business account conversion" or "(#10) Not enough viewers for the media to show insights" in str(
+            resp_json.get("error", {}).get("message")
         ):
             return
         for row in resp_json["data"]:
@@ -674,12 +670,10 @@ class StoryInsightsStream(InstagramStream):
         return params
 
     def validate_response(self, response: requests.Response) -> None:
-        if (
-            response.json().get("error", {}).get("error_user_title")
-            == "Media posted before business account conversion"
-            or
-            "(#10) Not enough viewers for the media to show insights"
-            in str(response.json().get("error", {}).get("message"))
+        if response.json().get("error", {}).get(
+            "error_user_title"
+        ) == "Media posted before business account conversion" or "(#10) Not enough viewers for the media to show insights" in str(
+            response.json().get("error", {}).get("message")
         ):
             self.logger.warning(f"Skipping: {response.json()['error']}")
             return
@@ -689,12 +683,10 @@ class StoryInsightsStream(InstagramStream):
         resp_json = response.json()
         # Handle the specific case where FB returns error because media was posted before business acct creation
         # TODO: Refactor to raise a specific error in validate_response and handle that instead
-        if (
-            resp_json.get("error", {}).get("error_user_title")
-            == "Media posted before business account conversion"
-            or
-            "(#10) Not enough viewers for the media to show insights"
-            in str(resp_json.get("error", {}).get("message"))
+        if resp_json.get("error", {}).get(
+            "error_user_title"
+        ) == "Media posted before business account conversion" or "(#10) Not enough viewers for the media to show insights" in str(
+            resp_json.get("error", {}).get("message")
         ):
             return
         for row in resp_json["data"]:


### PR DESCRIPTION
Ticket: https://vmproduct.atlassian.net/browse/CDT-441?atlOrigin=eyJpIjoiZGMxZmY2ODMyYWU1NDQxM2FlODA2N2U4NTBmMWRmNzMiLCJwIjoiaiJ9

Solves a problem that was causing premature failure of a bunch of Instagram pipelines.

Before, if a number of different streams encountered a 400 error (which is quite common and not necessarily a big problem), the entire meltano job would fail.

Now, if any stream that inherits from the parent InstagramStream object encounters that specific response (a 400 error with "Unsupported get request" in the message), the tap will log that it's skipping that stream instance and moving on to the next one.