### PR TITLE
fix - Remove total_interactions from videos

### DIFF
--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -472,13 +472,14 @@ class MediaInsightsStream(InstagramStream):
                 ]
             else:  # media_product_type is "AD" or "FEED"
                 metrics = [
-                    "total_interactions",
                     "impressions",
                     "reach",
                     "saved",
                 ]
                 if media_type == "VIDEO":
                     metrics.append("video_views")
+                else:
+                    metrics.append("total_interactions")
                 return metrics
         elif media_type == "CAROUSEL_ALBUM":
             return [


### PR DESCRIPTION
Throws an error for that media type, seems like that metric will undergo some deprecation soon anyway in the notice towards the top of here: https://developers.facebook.com/docs/instagram-api/reference/ig-media/insights/

```
singer_sdk.exceptions.FatalAPIError: 400 Client Error: Bad Request - (#100) Incompatible metric (total_interactions) with the media for path: /{media_id}/insights
```