### PR TITLE
Remove total_interactions metric for CAROUSEL_ALBUM

### DIFF
--- a/tap_instagram/streams.py
+++ b/tap_instagram/streams.py
@@ -472,17 +472,17 @@ class MediaInsightsStream(InstagramStream):
                 ]
             else:  # media_product_type is "AD" or "FEED"
                 metrics = [
-                    "total_interactions",
                     "impressions",
                     "reach",
                     "saved",
                 ]
                 if media_type == "VIDEO":
                     metrics.append("video_views")
+                else:
+                    metrics.append("total_interactions")
                 return metrics
         elif media_type == "CAROUSEL_ALBUM":
             return [
-                "total_interactions",
                 "impressions",
                 "reach",
                 "saved",


### PR DESCRIPTION
IG pipelines started failing on Mar 7, 2024 with the below error:
 400 Client Error: Bad Request - (#100) Incompatible metric (total_interactions) with the media for path: /{media_id}/insights
![Screen Shot 2024-03-07 at 5 35 27 PM](https://github.com/voxmedia/tap-instagram/assets/102059860/6d32e973-1adb-400f-bde6-b774f9431508)

The error seemed to be specific for CAROUSEL_ALBUM  though the IG API docs still mention about using total_interactions metric.
 
![Screen Shot 2024-03-07 at 5 36 06 PM](https://github.com/voxmedia/tap-instagram/assets/102059860/ef09b974-5497-4348-a210-ed17718c0a6d)

The pipeline ran successfully from local with this change.